### PR TITLE
Implement ExposeRuntimeCssAssetsPlugin for webpack users.

### DIFF
--- a/ExposeRuntimeCssAssetsPlugin.cjs
+++ b/ExposeRuntimeCssAssetsPlugin.cjs
@@ -27,9 +27,6 @@ module.exports = class ExposeRuntimeCssAssetsPlugin {
       compilation.hooks.afterOptimizeChunks.tap(
         "SingleSpaCssPlugin",
         (chunks) => {
-          compiler;
-          compilation;
-          debugger;
           chunks.forEach((chunk) => {
             if (chunk.hasEntryModule()) {
               let foundCssModule = false;

--- a/ExposeRuntimeCssAssetsPlugin.cjs
+++ b/ExposeRuntimeCssAssetsPlugin.cjs
@@ -1,0 +1,67 @@
+const webpack = require("webpack");
+const RuntimeModule = require("webpack/lib/RuntimeModule");
+const Template = require("webpack/lib/Template");
+const { RuntimeGlobals } = require("webpack");
+const { MODULE_TYPE } = require("mini-css-extract-plugin/dist/utils");
+
+class ExposedCssRuntimeModule extends RuntimeModule {
+  constructor(options) {
+    super("exposed-css-runtime", 10);
+    this.options = options;
+  }
+  generate() {
+    return Template.asString(
+      `${RuntimeGlobals.require}.cssAssets = ${JSON.stringify(
+        this.options.assets
+      )};`
+    );
+  }
+}
+
+module.exports = class ExposeRuntimeCssAssetsPlugin {
+  constructor(options) {
+    this.options = options;
+  }
+  apply(compiler) {
+    compiler.hooks.compilation.tap("SingleSpaCssPlugin", (compilation) => {
+      compilation.hooks.afterOptimizeChunks.tap(
+        "SingleSpaCssPlugin",
+        (chunks) => {
+          compiler;
+          compilation;
+          debugger;
+          chunks.forEach((chunk) => {
+            if (chunk.hasEntryModule()) {
+              let foundCssModule = false;
+              for (let module of chunk.getModules()) {
+                if (module.type === MODULE_TYPE) {
+                  foundCssModule = true;
+                  break;
+                }
+              }
+
+              if (foundCssModule) {
+                compilation.addRuntimeModule(
+                  chunk,
+                  new webpack.runtime.GetChunkFilenameRuntimeModule(
+                    MODULE_TYPE,
+                    "single-spa-css",
+                    `${webpack.RuntimeGlobals.require}.cssAssetFilePath`,
+                    (referencedChunk) => {
+                      return this.options.filename;
+                    },
+                    true
+                  )
+                );
+                compilation.addRuntimeModule(
+                  chunk,
+                  new ExposedCssRuntimeModule({ assets: [chunk.name] })
+                );
+              }
+            }
+          });
+        }
+      );
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepublishOnly": "pnpm run build",
     "check-format": "prettier --check .",
     "build:code": "rollup -c",
+    "watch:build": "rollup -cw",
     "build:types": "tsc",
     "format": "prettier --write .",
     "lint": "eslint src --ext ts"
@@ -22,7 +23,8 @@
     }
   },
   "files": [
-    "lib"
+    "lib",
+    "ExposeRuntimeCssAssetsPlugin.cjs"
   ],
   "repository": {
     "type": "git",
@@ -58,5 +60,8 @@
     "single-spa": "^5.9.0",
     "tslib": "^2.1.0",
     "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "@types/webpack-env": "^1.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-eslint": "^11.0.0-beta.2",
     "babel-jest": "^26.6.3",
     "concurrently": "^5.3.0",
-    "eslint": "^7.18.0",
+    "eslint": "^7.19.0",
     "eslint-config-ts-important-stuff": "^1.1.0",
     "husky": "^4.3.8",
     "jest": "^26.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,10 @@ devDependencies:
   '@testing-library/dom': 7.29.4
   '@testing-library/jest-dom': 5.11.9
   '@types/jest': 26.0.20
-  babel-eslint: 11.0.0-beta.2_b5d2baead2359fee426c65690feab125
+  babel-eslint: 11.0.0-beta.2_4040d347f50623727eb9d26c8bacfc4b
   babel-jest: 26.6.3_@babel+core@7.12.10
   concurrently: 5.3.0
-  eslint: 7.18.0
+  eslint: 7.19.0
   eslint-config-ts-important-stuff: 1.1.0
   husky: 4.3.8
   jest: 26.6.3
@@ -32,6 +32,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  /@babel/code-frame/7.12.13:
+    dependencies:
+      '@babel/highlight': 7.12.13
+    dev: true
+    resolution:
+      integrity: sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
   /@babel/compat-data/7.12.7:
     dev: true
     resolution:
@@ -252,6 +258,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  /@babel/highlight/7.12.13:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.12.11
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+    resolution:
+      integrity: sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
   /@babel/parser/7.12.11:
     dev: true
     engines:
@@ -1449,7 +1463,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  /ajv/7.0.3:
+  /ajv/7.0.4:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -1457,7 +1471,7 @@ packages:
       uri-js: 4.4.1
     dev: true
     resolution:
-      integrity: sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==
+      integrity: sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==
   /ansi-colors/4.1.1:
     dev: true
     engines:
@@ -1616,10 +1630,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-  /babel-eslint/11.0.0-beta.2_b5d2baead2359fee426c65690feab125:
+  /babel-eslint/11.0.0-beta.2_4040d347f50623727eb9d26c8bacfc4b:
     dependencies:
       '@babel/core': 7.12.10
-      eslint: 7.18.0
+      eslint: 7.19.0
       eslint-scope: 5.0.0
       eslint-visitor-keys: 1.3.0
       semver: 6.3.0
@@ -2361,9 +2375,9 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
-  /eslint/7.18.0:
+  /eslint/7.19.0:
     dependencies:
-      '@babel/code-frame': 7.12.11
+      '@babel/code-frame': 7.12.13
       '@eslint/eslintrc': 0.3.0
       ajv: 6.12.6
       chalk: 4.1.0
@@ -2405,7 +2419,7 @@ packages:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     resolution:
-      integrity: sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==
+      integrity: sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==
   /espree/7.3.1:
     dependencies:
       acorn: 7.4.1
@@ -5208,7 +5222,7 @@ packages:
       integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
   /table/6.0.7:
     dependencies:
-      ajv: 7.0.3
+      ajv: 7.0.4
       lodash: 4.17.20
       slice-ansi: 4.0.0
       string-width: 4.2.0
@@ -5728,7 +5742,7 @@ specifiers:
   babel-eslint: ^11.0.0-beta.2
   babel-jest: ^26.6.3
   concurrently: ^5.3.0
-  eslint: ^7.18.0
+  eslint: ^7.19.0
   eslint-config-ts-important-stuff: ^1.1.0
   husky: ^4.3.8
   jest: ^26.6.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,5 @@
+dependencies:
+  '@types/webpack-env': 1.16.0
 devDependencies:
   '@babel/core': 7.12.10
   '@babel/preset-env': 7.12.11_@babel+core@7.12.10
@@ -1392,6 +1394,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  /@types/webpack-env/1.16.0:
+    dev: false
+    resolution:
+      integrity: sha512-Fx+NpfOO0CpeYX2g9bkvX8O5qh9wrU1sOF4g8sft4Mu7z+qfe387YlyY8w8daDyDsKY5vUxM0yxkAYnbkRbZEw==
   /@types/yargs-parser/20.2.0:
     dev: true
     resolution:
@@ -4638,7 +4644,7 @@ packages:
       request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
-    deprecated: 'request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142'
+    deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     dev: true
     engines:
       node: '>=0.12.0'
@@ -4668,7 +4674,7 @@ packages:
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
       uuid: 3.4.0
-    deprecated: 'request has been deprecated, see https://github.com/request/request/issues/3142'
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     dev: true
     engines:
       node: '>= 6'
@@ -4711,7 +4717,7 @@ packages:
     resolution:
       integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
   /resolve-url/0.2.1:
-    deprecated: 'https://github.com/lydell/resolve-url#deprecated'
+    deprecated: https://github.com/lydell/resolve-url#deprecated
     dev: true
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
@@ -5452,7 +5458,7 @@ packages:
     resolution:
       integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   /urix/0.1.0:
-    deprecated: 'Please see https://github.com/lydell/urix#deprecated'
+    deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: true
     resolution:
       integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
@@ -5718,6 +5724,7 @@ specifiers:
   '@testing-library/dom': ^7.29.4
   '@testing-library/jest-dom': ^5.11.9
   '@types/jest': ^26.0.20
+  '@types/webpack-env': ^1.16.0
   babel-eslint: ^11.0.0-beta.2
   babel-jest: ^26.6.3
   concurrently: ^5.3.0

--- a/src/single-spa-css.test.ts
+++ b/src/single-spa-css.test.ts
@@ -1,4 +1,5 @@
 import * as singleSpa from "single-spa";
+import { createEmitAndSemanticDiagnosticsBuilderProgram } from "typescript";
 import singleSpaCss from "./single-spa-css";
 
 describe("single-spa-css", () => {
@@ -231,6 +232,42 @@ describe("single-spa-css", () => {
     );
 
     expect(mountSucceeded).toBe(false);
+  });
+
+  it(`correctly loads css assets exposed from ExposeRuntimeCssAssetsPlugin`, async () => {
+    // Simulate what ExposeRuntimeCssAssetsPlugin does
+    global.__webpack_public_path__ = "http://localhost:8080/";
+    global.__webpack_require__ = {
+      cssAssets: ["hi"],
+      cssAssetFileName(chunkId) {
+        return chunkId + ".css";
+      },
+    };
+
+    const lifecycles = singleSpaCss<{}>({
+      cssUrls: [],
+      webpackExtractedCss: true,
+    });
+
+    const props = createProps();
+
+    await lifecycles.bootstrap(props);
+
+    const mountPromise = lifecycles.mount(props);
+
+    await macroTick();
+
+    findLinkEl("http://localhost:8080/hi.css").dispatchEvent(
+      new CustomEvent("load")
+    );
+
+    await mountPromise;
+
+    expect(findLinkEl("http://localhost:8080/hi.css")).toBeInTheDocument();
+
+    await lifecycles.unmount(props);
+
+    expect(findLinkEl("http://localhost:8080/hi.css")).not.toBeInTheDocument();
   });
 });
 

--- a/src/single-spa-css.test.ts
+++ b/src/single-spa-css.test.ts
@@ -1,5 +1,4 @@
 import * as singleSpa from "single-spa";
-import { createEmitAndSemanticDiagnosticsBuilderProgram } from "typescript";
 import singleSpaCss from "./single-spa-css";
 
 describe("single-spa-css", () => {


### PR DESCRIPTION
This allows webpack users to use mini-css-extract-plugin and have that CSS automatically loaded as part of the mount lifecycle.

Example usage:

```js
// webpack.config.js
const ExposeRuntimeCssAssetsPlugin = require('single-spa-css/ExposeRuntimeCssAssetsPlugin.cjs');
const MiniCssExtractPlugin = require('mini-css-extract-plugin')

module.exports = {
  plugins: [
    new MiniCssExtractPlugin({filename: "[name].css"}),
    new ExposeRuntimeCssAssetsPlugin({filename: "[name].css"})
  ]
}
```

```js
// main.js
const cssLifecyles = singleSpaCss({
  cssUrls: [],
  webpackExtractedCss: true
})
```

Note that the webpack plugin only looks at the entry chunks, not code split chunks, for extracted CSS.