### PR TITLE
docs: clarify `required`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ import singleSpaCss from 'single-spa-css';
 
 const cssLifecycles = singleSpaCss({
   // required: a list of CSS URLs to load
+  // can be omitted if webpackExtractedCss is set to true, do not specify webpack extracted css files here
   cssUrls: ['https://example.com/main.css'],
 
   // optional: defaults to false. This controls whether extracted CSS files from webpack


### PR DESCRIPTION
At first I thought I needed to specify the names my webpack build had generated in cssUrls, but if webpackExtractedCss is true you should definitely not do that, since those css files will be loaded twice