### PR TITLE
Use the chunk id instead of the chunk name in the cssAssets array

### DIFF
--- a/ExposeRuntimeCssAssetsPlugin.cjs
+++ b/ExposeRuntimeCssAssetsPlugin.cjs
@@ -7,14 +7,13 @@ const { MODULE_TYPE } = require("mini-css-extract-plugin/dist/utils");
 const pluginName = "SingleSpaExposeRuntimeCssAssetsPlugin";
 
 class ExposedCssRuntimeModule extends RuntimeModule {
-  constructor(options) {
+  constructor() {
     super("exposed-css-runtime", 10);
-    this.options = options;
   }
   generate() {
     return Template.asString(
       `${RuntimeGlobals.require}.cssAssets = ${JSON.stringify(
-        this.options.assets
+        [this.chunk.id]
       )};`
     );
   }
@@ -100,7 +99,7 @@ module.exports = class ExposeRuntimeCssAssetsPlugin {
               );
               compilation.addRuntimeModule(
                 chunk,
-                new ExposedCssRuntimeModule({ assets: [chunk.name] })
+                new ExposedCssRuntimeModule()
               );
             }
           }

--- a/ExposeRuntimeCssAssetsPlugin.cjs
+++ b/ExposeRuntimeCssAssetsPlugin.cjs
@@ -12,9 +12,9 @@ class ExposedCssRuntimeModule extends RuntimeModule {
   }
   generate() {
     return Template.asString(
-      `${RuntimeGlobals.require}.cssAssets = ${JSON.stringify(
-        [this.chunk.id]
-      )};`
+      `${RuntimeGlobals.require}.cssAssets = ${JSON.stringify([
+        this.chunk.id,
+      ])};`
     );
   }
 }
@@ -67,11 +67,8 @@ module.exports = class ExposeRuntimeCssAssetsPlugin {
                 );
 
                 if (modules) {
-                  const {
-                    hashFunction,
-                    hashDigest,
-                    hashDigestLength,
-                  } = outputOptions;
+                  const { hashFunction, hashDigest, hashDigestLength } =
+                    outputOptions;
                   const hash = webpack.util.createHash(hashFunction);
 
                   for (const m of modules) {

--- a/ExposeRuntimeCssAssetsPlugin.cjs
+++ b/ExposeRuntimeCssAssetsPlugin.cjs
@@ -67,8 +67,11 @@ module.exports = class ExposeRuntimeCssAssetsPlugin {
                 );
 
                 if (modules) {
-                  const { hashFunction, hashDigest, hashDigestLength } =
-                    outputOptions;
+                  const {
+                    hashFunction,
+                    hashDigest,
+                    hashDigestLength,
+                  } = outputOptions;
                   const hash = webpack.util.createHash(hashFunction);
 
                   for (const m of modules) {


### PR DESCRIPTION
fixes: https://github.com/single-spa/single-spa-css/issues/11

`cssAssetFileNames` is a function that is generated by `GetChunkFilenameRuntimeModule`, which returns a function whose parameter name is chunkId.

In some builds this doesn't matter, because the output of the `cssAssetFileNames` minifies to something like: 
```
i.cssAssetFileName=e=>"main.4b69191f341ccadb8069.css"
```

making the actual value stored in `cssAssets` irrelevant.

But when using React.lazy, GetChunkFilenameRuntimeModule produces a more complicated function:

```
i.cssAssetFileName=e=>(179===e?"main":e)+"."+{179:"4b69191f341ccadb8069"}[e]+".css"
```

where the value of the parameter (chunkId / e) matters. Because we write the chunk _name_ to `cssAssets`, we break.

This has something to do with the fact that there is more than one chunk evaluated by GetChunkFilenameRuntimeModule.

We could sort of solve this problem like this

```
compilation.addRuntimeModule(
  chunk,
  new webpack.runtime.GetChunkFilenameRuntimeModule(
    MODULE_TYPE,
    "single-spa-css",
    `${webpack.RuntimeGlobals.require}.cssAssetFileName`,
    (referencedChunk) => {
      if (!referencedChunk.contentHash[MODULE_TYPE]) {
        return false;
      }

      return referencedChunk.canBeInitial()
        ? this.options.filename
        : this.options.chunkFilename;
    },
    true
  )
);
```

This seems more in line with the usage of GetChunkFilenameRuntimeModule in mini-css-extract-plugin,

but it only solves it by making the parameter value of cssAssetFileName irrelevant again:

```
i.cssAssetFileName=e=>"main.4b69191f341ccadb8069.css"
```

We could leave cssAssets alone and create (and use) a new cssAssetIds array instead, but I wasn't sure what the philosophy was around that sort of thing, so i opted for this simpler change.

