### PR TITLE
feat: support opts.manifestUrl for webpack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 Lifecycle helpers for loading and unmounting css.
 
 [Full Documentation](https://single-spa.js.org/docs/ecosystem-css#single-spa-css)
+
+manifestUrl 用法
+
+```js
+const cssLifecycles = singleSpaCss({
+  manifestUrl: `http://${host}/manifest.json`, //
+  webpackExtractedCss: false,
+});
+```
+
+> manifest 是 webpack-manifest-plugin 打包出的资源表
+> support development & production

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8451 @@
+{
+  "name": "single-spa-css",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha1-DfyAMJvuyEEeZecGRhxAiwu5tDE=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.0"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.16.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/compat-data/-/compat-data-7.16.4.tgz",
+      "integrity": "sha1-CB1rvDNuxcJDXGNGsq4fuYtaxo4=",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/core/-/core-7.16.5.tgz",
+      "integrity": "sha512-wUcenlLzuWMZ9Zt8S0KmFwGlH6QKRh3vsm/dhDA3CHkiTA45YuG1XkHRcNRl73EFPXDp/d5kVOU0/y7x2w6OaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.5",
+        "@babel/helper-compilation-targets": "^7.16.3",
+        "@babel/helper-module-transforms": "^7.16.5",
+        "@babel/helpers": "^7.16.5",
+        "@babel/parser": "^7.16.5",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.5",
+        "@babel/types": "^7.16.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/generator/-/generator-7.16.5.tgz",
+      "integrity": "sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+      "integrity": "sha1-mh8OvNpT2aLQAQjEzqzmpdXx8I0=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.5.tgz",
+      "integrity": "sha512-3JEA9G5dmmnIWdzaT9d0NmFRgYnWUThLsDaL7982H0XqqWr56lRrsmwheXFMjR+TMl7QMBb6mzy9kvgr1lRLUA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.16.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
+      "integrity": "sha1-W0gM0T9oNj327E3IrI4toRNjy/A=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.16.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.17.5",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.5.tgz",
+      "integrity": "sha512-NEohnYA7mkB8L5JhU7BLwcBdU3j83IziR9aseMueWGeAjblbul3zzb8UvJ3a1zuBiqCMObzCJHFqKIQE6hTVmg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-environment-visitor": "^7.16.5",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-member-expression-to-functions": "^7.16.5",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/helper-replace-supers": "^7.16.5",
+        "@babel/helper-split-export-declaration": "^7.16.0"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.0.tgz",
+      "integrity": "sha1-BrI0jON/zMT14Y3NjXUFPyp8RP8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "regexpu-core": "^4.7.1"
+      }
+    },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+      "integrity": "sha1-xbEM9LMk/4QBQLsH4FuFZK8q6XE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.5.tgz",
+      "integrity": "sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz",
+      "integrity": "sha1-dTAXM3oV9G+cCfZ0z/EM7pudd3g=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha1-t90Hl9ALv+5PB+nE6lsOMMi7FIE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha1-AIjHSGspqctdlIsaHeRttm4InPo=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha1-TJAjwvHe9+KP9G/B2802o5vqqBo=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.5.tgz",
+      "integrity": "sha512-7fecSXq7ZrLE+TWshbGT+HyCLkxloWNhTbU2QM1NTI/tDqyf0oZiMcEfYtDuUDCo528EOlt39G1rftea4bRZIw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha1-kFOOYLZy7PG0SPX09UM9N+eaPsM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-module-transforms/-/helper-module-transforms-7.16.5.tgz",
+      "integrity": "sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.16.5",
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-simple-access": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.5",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
+      "integrity": "sha1-zs2xRdcMVAlrFWT46fEM19GTszg=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+      "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==",
+      "dev": true
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.5.tgz",
+      "integrity": "sha512-X+aAJldyxrOmN9v3FKp+Hu1NO69VWgYgDGq6YDykwRPzxs5f2N+X988CBXS7EQahDU+Vpet5QYMqLk+nsp+Qxw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-wrap-function": "^7.16.5",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-replace-supers/-/helper-replace-supers-7.16.5.tgz",
+      "integrity": "sha512-ao3seGVa/FZCMCCNDuBcqnBFSbdr8N2EW35mzojx3TwfIbdPmNK+JV6+2d5bR0Z71W5ocLnQp9en/cTF7pBJiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.16.5",
+        "@babel/helper-member-expression-to-functions": "^7.16.5",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/traverse": "^7.16.5",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
+      "integrity": "sha1-IdaidiDjg+N1NM9sELugGab5BRc=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
+      "integrity": "sha1-DuM4gHAUfDrgUeSH7KPrsOLouwk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha1-KWcvQ2Y+k23zcKrrIr7ds7rsdDg=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.15.7",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k=",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha1-bnKh//GNXfy4eOHmLxoCHEty1aM=",
+      "dev": true
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helper-wrap-function/-/helper-wrap-function-7.16.5.tgz",
+      "integrity": "sha512-2J2pmLBqUqVdJw78U0KPNdeE2qeuIyKoG4mKV7wAq3mc4jJG282UgjZw4ZYDnqiWQuS3Y3IYdF/AQ6CpyBV3VA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.5",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/helpers/-/helpers-7.16.5.tgz",
+      "integrity": "sha512-TLgi6Lh71vvMZGEkFuIxzaPsyeYCHQ5jJOOX1f0xXn0uciFuE8cEk0wyBquMcCxBXZ5BJhE2aUB7pnWTD150Tw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.5",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha1-bOsysspLj182H7f9gh4/3fShclo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.16.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/parser/-/parser-7.16.6.tgz",
+      "integrity": "sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==",
+      "dev": true
+    },
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.16.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.2.tgz",
+      "integrity": "sha1-KXf8qbIS2xU8GVZ05Xz6uAdzMYM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.0.tgz",
+      "integrity": "sha1-NYly6qsAb16wgmGDsMk8vK8T4eI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.0"
+      }
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.5.tgz",
+      "integrity": "sha512-C/FX+3HNLV6sz7AqbTQqEo1L9/kfrKjxcVtgyBCmvIgOjvuBVUWooDoi7trsLxOzCEo5FccjRvKHkfDsJFZlfA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-remap-async-to-generator": "^7.16.5",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.5.tgz",
+      "integrity": "sha512-pJD3HjgRv83s5dv1sTnDbZOaTjghKEz8KUn1Kbh2eAIRhGuyQ1XSeI4xVXU3UlIEVA3DAyIdxqT1eRn7Wcn55A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-proposal-class-static-block": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.5.tgz",
+      "integrity": "sha512-EEFzuLZcm/rNJ8Q5krK+FRKdVkd6FjfzT9tuSZql9sQn64K0hHA2KLJ0DqVot9/iV6+SsuadC5yI39zWnm+nmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.5.tgz",
+      "integrity": "sha512-P05/SJZTTvHz79LNYTF8ff5xXge0kk5sIIWAypcWgX4BTRUgyHc8wRxJ/Hk+mU0KXldgOOslKaeqnhthcDJCJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.5.tgz",
+      "integrity": "sha512-i+sltzEShH1vsVydvNaTRsgvq2vZsfyrd7K7vPLUU/KgS0D5yZMe6uipM0+izminnkKrEfdUnz7CxMRb6oHZWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.5.tgz",
+      "integrity": "sha512-QQJueTFa0y9E4qHANqIvMsuxM/qcLQmKttBACtPCQzGUEizsXDACGonlPiSwynHfOa3vNw0FPMVvQzbuXwh4SQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.5.tgz",
+      "integrity": "sha512-xqibl7ISO2vjuQM+MzR3rkd0zfNWltk7n9QhaD8ghMmMceVguYrNDt7MikRyj4J4v3QehpnrU8RYLnC7z/gZLA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.5.tgz",
+      "integrity": "sha512-YwMsTp/oOviSBhrjwi0vzCUycseCYwoXnLiXIL3YNjHSMBHicGTz7GjVU/IGgz4DtOEXBdCNG72pvCX22ehfqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.5.tgz",
+      "integrity": "sha512-DvB9l/TcsCRvsIV9v4jxR/jVP45cslTVC0PMVHvaJhhNuhn2Y1SOhCSFlPK777qLB5wb8rVDaNoqMTyOqtY5Iw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.5.tgz",
+      "integrity": "sha512-UEd6KpChoyPhCoE840KRHOlGhEZFutdPDMGj+0I56yuTTOaT51GzmnEl/0uT41fB/vD2nT+Pci2KjezyE3HmUw==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-compilation-targets": "^7.16.3",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.16.5"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.5.tgz",
+      "integrity": "sha512-ihCMxY1Iljmx4bWy/PIMJGXN4NS4oUj1MKynwO07kiKms23pNvIn1DMB92DNB2R0EA882sw0VXIelYGdtF7xEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.5.tgz",
+      "integrity": "sha512-kzdHgnaXRonttiTfKYnSVafbWngPPr2qKw9BWYBESl91W54e+9R5pP70LtWxV56g0f05f/SQrwHYkfvbwcdQ/A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.5.tgz",
+      "integrity": "sha512-+yFMO4BGT3sgzXo+lrq7orX5mAZt57DwUK6seqII6AcJnJOIhBJ8pzKH47/ql/d426uQ7YhN8DpUFirQzqYSUA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.5.tgz",
+      "integrity": "sha512-+YGh5Wbw0NH3y/E5YMu6ci5qTDmAEVNoZ3I54aB6nVEOZ5BQ7QJlwKq5pYVucQilMByGn/bvX0af+uNaPRCabA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-create-class-features-plugin": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.5.tgz",
+      "integrity": "sha512-s5sKtlKQyFSatt781HQwv1hoM5BQ9qRH30r+dK56OLDsHmV74mzwJNX7R1yMuE7VZKG5O6q/gmOGSAO6ikTudg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha1-GV34mxRrS3izv4l/16JXyEZZ1AY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha1-AolkqbqA28CUyRXEh618TnpmRlo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha1-DcZnHsDqIrbpShEU+FeXDNOd4a0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.5.tgz",
+      "integrity": "sha512-/d4//lZ1Vqb4mZ5xTep3dDK888j7BGM/iKqBmndBaoYAFPlPKrGU608VVBz5JeyAb6YQDjRu1UKqj86UhwWVgw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.5.tgz",
+      "integrity": "sha512-8bTHiiZyMOyfZFULjsCnYOWG059FVMes0iljEHSfARhNgFfpsqE92OrCffv3veSw9rwMkYcFe9bj0ZoXU2IGtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.5.tgz",
+      "integrity": "sha512-TMXgfioJnkXU+XRoj7P2ED7rUm5jbnDWwlCuFVTpQboMfbSya5WrmubNBAMlk7KXvywpo8rd8WuYZkis1o2H8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-remap-async-to-generator": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.5.tgz",
+      "integrity": "sha512-BxmIyKLjUGksJ99+hJyL/HIxLIGnLKtw772zYDER7UuycDZ+Xvzs98ZQw6NGgM2ss4/hlFAaGiZmMNKvValEjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.5.tgz",
+      "integrity": "sha512-JxjSPNZSiOtmxjX7PBRBeRJTUKTyJ607YUYeT0QJCNdsedOe+/rXITjP08eG8xUpsLfPirgzdCFN+h0w6RI+pQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.5.tgz",
+      "integrity": "sha512-DzJ1vYf/7TaCYy57J3SJ9rV+JEuvmlnvvyvYKFbk5u46oQbBvuB9/0w+YsVsxkOv8zVWKpDmUoj4T5ILHoXevA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-environment-visitor": "^7.16.5",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-replace-supers": "^7.16.5",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.5.tgz",
+      "integrity": "sha512-n1+O7xtU5lSLraRzX88CNcpl7vtGdPakKzww74bVwpAIRgz9JVLJJpOLb0uYqcOaXVM0TL6X0RVeIJGD2CnCkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.5.tgz",
+      "integrity": "sha512-GuRVAsjq+c9YPK6NeTkRLWyQskDC099XkBSVO+6QzbnOnH2d/4mBVXYStaPrZD3dFRfg00I6BFJ9Atsjfs8mlg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.5.tgz",
+      "integrity": "sha512-iQiEMt8Q4/5aRGHpGVK2Zc7a6mx7qEAO7qehgSug3SDImnuMzgmm/wtJALXaz25zUj1PmnNHtShjFgk4PDx4nw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.5.tgz",
+      "integrity": "sha512-81tijpDg2a6I1Yhj4aWY1l3O1J4Cg/Pd7LfvuaH2VVInAkXtzibz9+zSPdUM1WvuUi128ksstAP0hM5w48vQgg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.5.tgz",
+      "integrity": "sha512-12rba2HwemQPa7BLIKCzm1pT2/RuQHtSFHdNl41cFiC6oi4tcrp7gjB07pxQvFpcADojQywSjblQth6gJyE6CA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.5.tgz",
+      "integrity": "sha512-+DpCAJFPAvViR17PIMi9x2AE34dll5wNlXO43wagAX2YcRGgEVHCNFC4azG85b4YyyFarvkc/iD5NPrz4Oneqw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.5.tgz",
+      "integrity": "sha512-Fuec/KPSpVLbGo6z1RPw4EE1X+z9gZk1uQmnYy7v4xr4TO9p41v1AoUuXEtyqAI7H+xNJYSICzRqZBhDEkd3kQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.5.tgz",
+      "integrity": "sha512-B1j9C/IfvshnPcklsc93AVLTrNVa69iSqztylZH6qnmiAsDDOmmjEYqOm3Ts2lGSgTSywnBNiqC949VdD0/gfw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.5.tgz",
+      "integrity": "sha512-d57i3vPHWgIde/9Y8W/xSFUndhvhZN5Wu2TjRrN1MVz5KzdUihKnfDVlfP1U7mS5DNj/WHHhaE4/tTi4hIyHwQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.5.tgz",
+      "integrity": "sha512-oHI15S/hdJuSCfnwIz+4lm6wu/wBn7oJ8+QrkzPPwSFGXk8kgdI/AIKcbR/XnD1nQVMg/i6eNaXpszbGuwYDRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.5.tgz",
+      "integrity": "sha512-ABhUkxvoQyqhCWyb8xXtfwqNMJD7tx+irIRnUh6lmyFud7Jln1WzONXKlax1fg/ey178EXbs4bSGNd6PngO+SQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-simple-access": "^7.16.0",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.5.tgz",
+      "integrity": "sha512-53gmLdScNN28XpjEVIm7LbWnD/b/TpbwKbLk6KV4KqC9WyU6rq1jnNmVG6UgAdQZVVGZVoik3DqHNxk4/EvrjA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.5.tgz",
+      "integrity": "sha512-qTFnpxHMoenNHkS3VoWRdwrcJ3FhX567GvDA3hRZKF0Dj8Fmg0UzySZp3AP2mShl/bzcywb/UWAMQIjA1bhXvw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.5.tgz",
+      "integrity": "sha512-/wqGDgvFUeKELW6ex6QB7dLVRkd5ehjw34tpXu1nhKC0sFfmaLabIswnpf8JgDyV2NeDmZiwoOb0rAmxciNfjA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.5.tgz",
+      "integrity": "sha512-ZaIrnXF08ZC8jnKR4/5g7YakGVL6go6V9ql6Jl3ecO8PQaQqFE74CuM384kezju7Z9nGCCA20BqZaR1tJ/WvHg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.5.tgz",
+      "integrity": "sha512-tded+yZEXuxt9Jdtkc1RraW1zMF/GalVxaVVxh41IYwirdRgyAxxxCKZ9XB7LxZqmsjfjALxupNE1MIz9KH+Zg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-replace-supers": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.5.tgz",
+      "integrity": "sha512-B3O6AL5oPop1jAVg8CV+haeUte9oFuY85zu0jwnRNZZi3tVAbJriu5tag/oaO2kGaQM/7q7aGPBlTI5/sr9enA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.5.tgz",
+      "integrity": "sha512-+IRcVW71VdF9pEH/2R/Apab4a19LVvdVsr/gEeotH00vSDVlKD+XgfSIw+cgGWsjDB/ziqGv/pGoQZBIiQVXHg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.5.tgz",
+      "integrity": "sha512-2z+it2eVWU8TtQQRauvGUqZwLy4+7rTfo6wO4npr+fvvN1SW30ZF3O/ZRCNmTuu4F5MIP8OJhXAhRV5QMJOuYg==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.5.tgz",
+      "integrity": "sha512-aIB16u8lNcf7drkhXJRoggOxSTUAuihTSTfAcpynowGJOZiGf+Yvi7RuTwFzVYSYPmWyARsPqUGoZWWWxLiknw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.5.tgz",
+      "integrity": "sha512-ZbuWVcY+MAXJuuW7qDoCwoxDUNClfZxoo7/4swVbOW1s/qYLOMHlm9YRWMsxMFuLs44eXsv4op1vAaBaBaDMVg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.5.tgz",
+      "integrity": "sha512-5d6l/cnG7Lw4tGHEoga4xSkYp1euP7LAtrah1h1PgJ3JY7yNsjybsxQAnVK4JbtReZ/8z6ASVmd3QhYYKLaKZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.5.tgz",
+      "integrity": "sha512-usYsuO1ID2LXxzuUxifgWtJemP7wL2uZtyrTVM4PKqsmJycdS4U4mGovL5xXkfUheds10Dd2PjoQLXw6zCsCbg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.5.tgz",
+      "integrity": "sha512-gnyKy9RyFhkovex4BjKWL3BVYzUDG6zC0gba7VMLbQoDuqMfJ1SDXs8k/XK41Mmt1Hyp4qNAvGFb9hKzdCqBRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.5.tgz",
+      "integrity": "sha512-ldxCkW180qbrvyCVDzAUZqB0TAeF8W/vGJoRcaf75awm6By+PxfJKvuqVAnq8N9wz5Xa6mSpM19OfVKKVmGHSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.16.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.1.tgz",
+      "integrity": "sha1-zAZwsoIrAzg1W8Gz0iRqQrgWZAk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.16.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-escapes": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.5.tgz",
+      "integrity": "sha512-shiCBHTIIChGLdyojsKQjoAyB8MBwat25lKM7MJjbe1hE0bgIppD+LX9afr41lLHOhqceqeWl4FkLp+Bgn9o1Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.5.tgz",
+      "integrity": "sha512-GTJ4IW012tiPEMMubd7sD07iU9O/LOo8Q/oU4xNhcaq0Xn8+6TcUQaHtC8YxySo1T+ErQ8RaWogIEeFhKGNPzw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.16.5"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/preset-env/-/preset-env-7.16.5.tgz",
+      "integrity": "sha512-MiJJW5pwsktG61NDxpZ4oJ1CKxM1ncam9bzRtx9g40/WkLRkxFP6mhpkYV0/DxcciqoiHicx291+eUQrXb/SfQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-compilation-targets": "^7.16.3",
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.2",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.16.5",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-class-static-block": "^7.16.5",
+        "@babel/plugin-proposal-dynamic-import": "^7.16.5",
+        "@babel/plugin-proposal-export-namespace-from": "^7.16.5",
+        "@babel/plugin-proposal-json-strings": "^7.16.5",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.16.5",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.5",
+        "@babel/plugin-proposal-numeric-separator": "^7.16.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.16.5",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.16.5",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.5",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.16.5",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5",
+        "@babel/plugin-transform-arrow-functions": "^7.16.5",
+        "@babel/plugin-transform-async-to-generator": "^7.16.5",
+        "@babel/plugin-transform-block-scoped-functions": "^7.16.5",
+        "@babel/plugin-transform-block-scoping": "^7.16.5",
+        "@babel/plugin-transform-classes": "^7.16.5",
+        "@babel/plugin-transform-computed-properties": "^7.16.5",
+        "@babel/plugin-transform-destructuring": "^7.16.5",
+        "@babel/plugin-transform-dotall-regex": "^7.16.5",
+        "@babel/plugin-transform-duplicate-keys": "^7.16.5",
+        "@babel/plugin-transform-exponentiation-operator": "^7.16.5",
+        "@babel/plugin-transform-for-of": "^7.16.5",
+        "@babel/plugin-transform-function-name": "^7.16.5",
+        "@babel/plugin-transform-literals": "^7.16.5",
+        "@babel/plugin-transform-member-expression-literals": "^7.16.5",
+        "@babel/plugin-transform-modules-amd": "^7.16.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.16.5",
+        "@babel/plugin-transform-modules-systemjs": "^7.16.5",
+        "@babel/plugin-transform-modules-umd": "^7.16.5",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.5",
+        "@babel/plugin-transform-new-target": "^7.16.5",
+        "@babel/plugin-transform-object-super": "^7.16.5",
+        "@babel/plugin-transform-parameters": "^7.16.5",
+        "@babel/plugin-transform-property-literals": "^7.16.5",
+        "@babel/plugin-transform-regenerator": "^7.16.5",
+        "@babel/plugin-transform-reserved-words": "^7.16.5",
+        "@babel/plugin-transform-shorthand-properties": "^7.16.5",
+        "@babel/plugin-transform-spread": "^7.16.5",
+        "@babel/plugin-transform-sticky-regex": "^7.16.5",
+        "@babel/plugin-transform-template-literals": "^7.16.5",
+        "@babel/plugin-transform-typeof-symbol": "^7.16.5",
+        "@babel/plugin-transform-unicode-escapes": "^7.16.5",
+        "@babel/plugin-transform-unicode-regex": "^7.16.5",
+        "@babel/preset-modules": "^0.1.5",
+        "@babel/types": "^7.16.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "core-js-compat": "^3.19.1",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+      "integrity": "sha1-75Odbn8miCfhhBY43G/5VRXhFdk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/preset-typescript/-/preset-typescript-7.16.5.tgz",
+      "integrity": "sha512-lmAWRoJ9iOSvs3DqOndQpj8XqXkzaiQs50VG/zESiI9D3eoZhGriU675xNCr0UwvsuXrhMAGvyk1w+EVWF3u8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-typescript": "^7.16.1"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/runtime/-/runtime-7.16.5.tgz",
+      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/runtime-corejs3/-/runtime-corejs3-7.16.5.tgz",
+      "integrity": "sha512-F1pMwvTiUNSAM8mc45kccMQxj31x3y3P+tA/X8hKNWp3/hUsxdGxZ3D3H8JIkxtfA8qGkaBTKvcmvStaYseAFw==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.19.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha1-0Wo16/TNdOICCDNW+rId2JNj3dY=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.16.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/traverse/-/traverse-7.16.5.tgz",
+      "integrity": "sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.5",
+        "@babel/helper-environment-visitor": "^7.16.5",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.5",
+        "@babel/types": "^7.16.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.16.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha1-2zsxOAT5aq3Qt3bEgj4SetZyibo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
+      "dev": true
+    },
+    "@cnakazawa/watch": {
+      "version": "1.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha1-+GSuhQBND8q29QvpFBxNo2jRZWo=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.4.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha1-nkKYHvA1vrPdSa3ResuW6P9vOUw=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.12.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha1-TXM3YDBCMKAILtluIeXFZfiYCJ4=",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        }
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha1-FAeWfUxu7Nc4j4Os8er00Mbljvk=",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha1-tSBSnsIdjllFoYUd/Rwy6U45/0U=",
+      "dev": true
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/console/-/console-26.6.2.tgz",
+      "integrity": "sha1-TgS8RkAUNYsDq0k3gF7jagrrmPI=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/core": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/core/-/core-26.6.3.tgz",
+      "integrity": "sha1-djn8s4M9dIpGVq2lS94ZMFHkX60=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/reporters": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-changed-files": "^26.6.2",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-resolve-dependencies": "^26.6.3",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "jest-watcher": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/environment/-/environment-26.6.2.tgz",
+      "integrity": "sha1-ujZMxy4iHnnMjwqZVVv111d8+Sw=",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+      "integrity": "sha1-RZwym89wzuSvTX4/PmeEgSNTWq0=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@types/node": "*",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
+      }
+    },
+    "@jest/globals": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/globals/-/globals-26.6.2.tgz",
+      "integrity": "sha1-W2E7eKGqJlWukI66Y4zJaiDfcgo=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "expect": "^26.6.2"
+      }
+    },
+    "@jest/reporters": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/reporters/-/reporters-26.6.2.tgz",
+      "integrity": "sha1-H1GLmWN6Xxgwe9Ps+SdfaIKmZ/Y=",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.2.4",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.3",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "jest-haste-map": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^4.0.1",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+          "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/source-map": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/source-map/-/source-map-26.6.2.tgz",
+      "integrity": "sha1-Ka9eHi4yTK/MyTbyGDCfVKtp1TU=",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.4",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@jest/test-result": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/test-result/-/test-result-26.6.2.tgz",
+      "integrity": "sha1-VdpYti3xNFdsyVR276X3lJ4/Xxg=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+      "integrity": "sha1-mOikUQCGOIbQdCBej/3Fp+tYKxc=",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^26.6.2",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^26.6.2",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3"
+      }
+    },
+    "@jest/transform": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/transform/-/transform-26.6.2.tgz",
+      "integrity": "sha1-WsV8X6GtF7Kq6D5z5FgTiU3PLks=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^26.6.2",
+        "babel-plugin-istanbul": "^6.0.0",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-util": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "pirates": "^4.0.1",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@rollup/plugin-typescript": {
+      "version": "8.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@rollup/plugin-typescript/-/plugin-typescript-8.3.0.tgz",
+      "integrity": "sha1-vBB3+liXuYD8J+N2xON3iCxj5os=",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha1-OALd0hpQqUm2ch3dcto25n5/Gy0=",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha1-KTZ0/MsyYqx4LHqt/eyoaxDHXEA=",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "7.31.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@testing-library/dom/-/dom-7.31.2.tgz",
+      "integrity": "sha1-3zYds49SEriFVQaKuBGfXYQajEo=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.6",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.16.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@testing-library/jest-dom/-/jest-dom-5.16.1.tgz",
+      "integrity": "sha512-ajUJdfDIuTCadB79ukO+0l8O+QwN0LiSxDaYUTI4LndbbUsGi6rWU1SCexXzBA2NSjlVB9/vbkasQIL3tmPBjw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "5.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/aria-query/-/aria-query-5.0.0.tgz",
+          "integrity": "sha1-IQwhqvRpYT7oyaYsf4ZSXgWNtSw=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I=",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha1-7U4K2SMGpwT5+xMqDPz3dIbb4rw=",
+      "dev": true
+    },
+    "@types/babel__core": {
+      "version": "7.1.17",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/babel__core/-/babel__core-7.1.17.tgz",
+      "integrity": "sha512-6zzkezS9QEIL8yCBvXWxPTJPNuMeECJVxSOhxNY/jfq9LxOTHivaYTqr37n9LknWWRTIkzqH2UilS5QFvfa90A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/babel__generator/-/babel__generator-7.6.4.tgz",
+      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha1-PRpI/Z1sDt/Vby/1eNrtSPNsiWk=",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.14.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha1-/81HC7s/i/MEgWePtVAieMqDOkM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha1-4Xfmme4bjCLSMXTKqnQiZEOJUJ8=",
+      "dev": true
+    },
+    "@types/graceful-fs": {
+      "version": "4.1.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+      "integrity": "sha1-If+6DZjaQ1DbZIkfkqnl2zzbThU=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-wUwk8Y6oGQwRjudWK3/5mjZVJoY=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha1-kVP+mLuivVZaY63ZQ21vDX+EaP8=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "26.0.24",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha1-lD0Rl2sWc5GFkToZNuDeDEp9WVo=",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/node/-/node-17.0.4.tgz",
+      "integrity": "sha512-6xwbrW4JJiJLgF+zNypN5wr2ykM9/jHcL7rQ8fZe2vuftggjzZeRSM4OwRc6Xk8qWjwJ99qVHo/JgOGmomWRog==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha1-0zV0eaD9/dWQf+Z+F+CoXJBuEwE=",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA=",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "2.4.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/prettier/-/prettier-2.4.2.tgz",
+      "integrity": "sha1-TGL66T60eWYMO9k/nSTVYVl6goE=",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+      "integrity": "sha1-IPGClPeX8iCbX2XI47XI6CYdEnw=",
+      "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.14.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
+      "integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
+    },
+    "@types/webpack-env": {
+      "version": "1.16.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/webpack-env/-/webpack-env-1.16.3.tgz",
+      "integrity": "sha1-t3YyenPlYbceeIHQzW00oUJNuGo="
+    },
+    "@types/yargs": {
+      "version": "15.0.14",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha1-Jtgh3biecEkhYLZtEKDrbfj2+wY=",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha1-O5ziSJkZ2eT+pDm3aRarw0st8Sk=",
+      "dev": true
+    },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha1-wLZ4+zLWD8EhnHhNaoJv44Wut5o=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
+      "dev": true
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
+          "dev": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "http://ires.58corp.com/repository/58npm/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha1-DSymyazrVriXfp/tau1+FbvS+Ds=",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha1-PLs9DzFoEOr8xHYkc0I31q7krms=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha1-yWVekzHgq81YjSp8rX6ZVvZnAfo=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "babel-eslint": {
+      "version": "11.0.0-beta.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-eslint/-/babel-eslint-11.0.0-beta.2.tgz",
+      "integrity": "sha1-3h8GeVqg2M7c9qyUPmMFb1tKcEg=",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "5.0.0",
+        "eslint-visitor-keys": "^1.1.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "babel-jest": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-jest/-/babel-jest-26.6.3.tgz",
+      "integrity": "sha1-2H0lywA3V3oMifguV1XF0pPAEFY=",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/babel__core": "^7.1.7",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^26.6.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha1-hP2hnJduxcbe/vV/lCez3vZuF6M=",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+      "integrity": "sha1-gYW9AwNI0lTG192XQ1Xmoosh5i0=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+      "integrity": "sha1-QHCC0NNVulZa8kEm+2y46RFSUf0=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "semver": "^6.1.1"
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.4.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+      "integrity": "sha1-C1cfTPPWf5EVEvXASEKnuOgmMIc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "core-js-compat": "^3.18.0"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+      "integrity": "sha1-nrvNcYbhoz4hxeIMrk55g5SVM74=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.3.0"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+      "integrity": "sha1-dHhysRcd8DIlJCZYaIHWLTF5j+4=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^26.6.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/base/-/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "http://ires.58corp.com/repository/58npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
+      "dev": true
+    },
+    "browserslist": {
+      "version": "4.19.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/browserslist/-/browserslist-4.19.1.tgz",
+      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001292",
+      "resolved": "http://ires.58corp.com/repository/58npm/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
+      "dev": true
+    },
+    "capture-exit": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/capture-exit/-/capture-exit-2.0.0.tgz",
+      "integrity": "sha1-+5U7+uvreB9iiYI52rtCbQilCaQ=",
+      "dev": true,
+      "requires": {
+        "rsvp": "^4.8.4"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
+      "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "0.6.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+      "integrity": "sha1-QYb8yg6uF1lwruhwuf4tbPjVZV8=",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha1-zCyOlPwYu9/+ZNZTRXDIpnOyf1k=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "http://ires.58corp.com/repository/58npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha1-GlaJkTaF5ah2N7jT/8p1UU7EHWI=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concurrently": {
+      "version": "5.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/concurrently/-/concurrently-5.3.0.tgz",
+      "integrity": "sha1-dQDeZBDQQ8kSston3jICy0ibHns=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "date-fns": "^2.0.1",
+        "lodash": "^4.17.15",
+        "read-pkg": "^4.0.1",
+        "rxjs": "^6.5.2",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^6.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.20.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/core-js-compat/-/core-js-compat-3.20.1.tgz",
+      "integrity": "sha512-AVhKZNpqMV3Jz8hU0YEXXE06qoxtQGsAqU0u1neUngz5IusDJRX/ZJ6t3i7mS7QxNyEONbCo14GprkBrxPlTZA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.19.1",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44=",
+          "dev": true
+        }
+      }
+    },
+    "core-js-pure": {
+      "version": "3.20.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/core-js-pure/-/core-js-pure-3.20.1.tgz",
+      "integrity": "sha512-yeNNr3L9cEBwNy6vhhIJ0nko7fE7uFO6PgawcacGt2VWep4WqQx0RiqlkgSP7kqUMC1IKdfO9qPeWXcUheHLVQ==",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha1-cU11ZSLKzoZ4Z8y0R0xdAbuuXW0=",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        }
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/css/-/css-3.0.0.tgz",
+      "integrity": "sha1-REek1Y/dAzZ8UWyp9krjZc7kql0=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha1-WmbPk9LQtmHYC/akT7ZfXC5OChA=",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha1-/2ZaDdvcMYZLCWR/NBY0Q9kLCFI=",
+      "dev": true,
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "http://ires.58corp.com/repository/58npm/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
+          "dev": true
+        }
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha1-FWSFpyljqXD11YIar2Qr7yvy25s=",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      }
+    },
+    "date-fns": {
+      "version": "2.27.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/date-fns/-/date-fns-2.27.0.tgz",
+      "integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha1-2MOkRKnGd0umDKatcmHDqU/V54M=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha1-SLqZFX3hkjQS7tQdtrbUqpynwLE=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "http://ires.58corp.com/repository/58npm/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha1-yqbQj2A4jQu0U53XX+RYqaHQAUw=",
+      "dev": true
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8=",
+          "dev": true
+        }
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.4.27",
+      "resolved": "http://ires.58corp.com/repository/58npm/electron-to-chromium/-/electron-to-chromium-1.4.27.tgz",
+      "integrity": "sha512-uZ95szi3zUbzRDx1zx/xnsCG+2xgZyy57pDOeaeO4r8zx5Dqe8Jv1ti8cunvBwJHVI5LzPuw8umKwZb3WKYxSQ==",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.7.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/emittery/-/emittery-0.7.2.tgz",
+      "integrity": "sha1-JVlZCOE68PVnSrQZOW4vs5TN+oI=",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha1-Kn/l3WNKHkElqXXsmU/1RW3Dc00=",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha1-XjKxKDPoqo+jXhvwvvqJOASEx90=",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
+    },
+    "eslint": {
+      "version": "7.32.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.9",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "http://ires.58corp.com/repository/58npm/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha1-9K1DWqJj25NbjxDyxVLSP7cWpj8=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha1-9lMoJZMFknOSyTjtROsKXJsr0wM=",
+          "dev": true
+        },
+        "globals": {
+          "version": "13.12.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha1-TXM3YDBCMKAILtluIeXFZfiYCJ4=",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-important-stuff": {
+      "version": "1.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/eslint-config-important-stuff/-/eslint-config-important-stuff-1.1.0.tgz",
+      "integrity": "sha1-9+2MMyFpZPr2gPiWnf4LGWyE5uI=",
+      "dev": true
+    },
+    "eslint-config-ts-important-stuff": {
+      "version": "1.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/eslint-config-ts-important-stuff/-/eslint-config-ts-important-stuff-1.1.0.tgz",
+      "integrity": "sha1-qFpq62RAfmWaih5Lud/OEhGcYw8=",
+      "dev": true,
+      "requires": {
+        "eslint-config-important-stuff": "^1.1.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha1-8t8zC3Usb1UBn4vYm3ZgA5wbu7Y=",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha1-MbxdYSyWtwQQa0d+bdXYqhOMtwA=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "dev": true
+    },
+    "exec-sh": {
+      "version": "0.3.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/exec-sh/-/exec-sh-0.3.6.tgz",
+      "integrity": "sha1-/yZPnjJVGaYMteJzaSlDSDzKY7w=",
+      "dev": true
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://ires.58corp.com/repository/58npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "expect": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/expect/-/expect-26.6.2.tgz",
+      "integrity": "sha1-xrmWvya/P+GLZ7LQ9R/JgbqTRBc=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "ansi-styles": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-regex-util": "^26.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fb-watchman": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha1-/IT7OdJwnPP/bXQ3BhV7tXCKioU=",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "find-versions": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha1-PFflc7+XdpuMuN8Wk0tieRXaSWU=",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^3.1.2"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha1-YbAzgwKy/p+Vfcwy/CqH8cMEixE=",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha1-KNmWnqkGYbUTQlnzEqtqp5KaxeI=",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/follow-redirects/-/follow-redirects-1.14.6.tgz",
+      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "http://ires.58corp.com/repository/58npm/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo=",
+      "dev": true
+    },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true,
+      "optional": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "http://ires.58corp.com/repository/58npm/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha1-QqbcT9M/ACgRduiyN1nKTk+hhfM=",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M=",
+      "dev": true
+    },
+    "husky": {
+      "version": "4.3.8",
+      "resolved": "http://ires.58corp.com/repository/58npm/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha1-MRRAYL6WP9aFDlzI8Bmh3+GUKW0=",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^4.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "http://ires.58corp.com/repository/58npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+          "dev": true
+        }
+      }
+    },
+    "import-local": {
+      "version": "3.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/import-local/-/import-local-3.0.3.tgz",
+      "integrity": "sha1-TVHCxJXKk5PaJZ7Ga2LgIpICEeA=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "dependencies": {
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        }
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.8.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "dev": true
+        }
+      }
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+      "dev": true,
+      "optional": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha1-GJ55CdCjn6Wj361bA/cZR3cBkdM=",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "5.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
+      "integrity": "sha1-e0kZi2V7J6cwuOnLYB8eG/8kxZo=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-dRj+UupE3jcvRgp2tezan/tz2KY=",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha1-iV86cJ/PujTG3lpCk5Ai8+Q1hVE=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/istanbul-reports/-/istanbul-reports-3.1.2.tgz",
+      "integrity": "sha512-0gHxuT1NNC0aEIL1zbJ+MTgPbbHhU77eJPuU35WKA7TgXiSNlCAx4PENoMrH0Or6M2H80TaZcWKhM0IK6V8gRw==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jest": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest/-/jest-26.6.3.tgz",
+      "integrity": "sha1-QOj9vkjwDfofDOgSHKdLiKyRSO8=",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^26.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^26.6.3"
+      }
+    },
+    "jest-changed-files": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+      "integrity": "sha1-9hmEeeHMZvIvmuHiKsqgtCnAQtA=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "execa": "^4.0.0",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha1-TlSRrRVy8vF6d9OIxshXE1sihHo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "jest-cli": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-cli/-/jest-cli-26.6.3.tgz",
+      "integrity": "sha1-QxF8/vJLxM1pGhdKh5alMuE16So=",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^26.6.3",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "import-local": "^3.0.2",
+        "is-ci": "^2.0.0",
+        "jest-config": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "prompts": "^2.0.1",
+        "yargs": "^15.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "jest-config": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-config/-/jest-config-26.6.3.tgz",
+      "integrity": "sha1-ZPQURO756wPcUdXFO3XIxx9kU0k=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^26.6.3",
+        "@jest/types": "^26.6.2",
+        "babel-jest": "^26.6.3",
+        "chalk": "^4.0.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-environment-jsdom": "^26.6.2",
+        "jest-environment-node": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "jest-jasmine2": "^26.6.3",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha1-GqdGi1LDpo19XF/c381eSb0WQ5Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-docblock": {
+      "version": "26.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-docblock/-/jest-docblock-26.0.0.tgz",
+      "integrity": "sha1-Pi+iCJn8koyxO9D/aL03EaNoibU=",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-each": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-each/-/jest-each-26.6.2.tgz",
+      "integrity": "sha1-AlJkOKd6Z0AcimOC3+WZmVLBZ8s=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+      "integrity": "sha1-eNCf6c8BmjVwCbm34fEB0jvR2j4=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jsdom": "^16.4.0"
+      }
+    },
+    "jest-environment-node": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+      "integrity": "sha1-gk5Mf7SURkY1bxGsdbIpsANfKww=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
+      }
+    },
+    "jest-get-type": {
+      "version": "26.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA=",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+      "integrity": "sha1-3X5g/n3A6fkRoj15xf9/tcLK/qo=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-regex-util": "^26.0.0",
+        "jest-serializer": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+      "integrity": "sha1-rcPPkV3qy1ISyTufNUfNEpWPLt0=",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "expect": "^26.6.2",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-leak-detector": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+      "integrity": "sha1-dxfPEYuSI48uumUFTIoMnGU6ka8=",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+      "integrity": "sha1-jm/W6GPIstMaxkcu6yN7xZXlPno=",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-message-util/-/jest-message-util-26.6.2.tgz",
+      "integrity": "sha1-WBc3RK1vwFBrXSEVC5vlbvABygc=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/types": "^26.6.2",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-mock/-/jest-mock-26.6.2.tgz",
+      "integrity": "sha1-1stxKwQe1H/g2bb8NHS8ZUP+swI=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha1-twSsCuAoqJEIpNBAs/kZ393I4zw=",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "26.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+      "integrity": "sha1-0l5xhLNuOf1GbDvEG+CXHoIf7ig=",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-resolve/-/jest-resolve-26.6.2.tgz",
+      "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^26.6.2",
+        "read-pkg-up": "^7.0.1",
+        "resolve": "^1.18.1",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+      "integrity": "sha1-ZoCFnuXSLuXc2WH+SHH1n0x4T7Y=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-snapshot": "^26.6.2"
+      }
+    },
+    "jest-runner": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-runner/-/jest-runner-26.6.3.tgz",
+      "integrity": "sha1-LR/tPUbhDyM/0dvTv6o/6JJL4Vk=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.7.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.6.3",
+        "jest-docblock": "^26.0.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-leak-detector": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "source-map-support": "^0.5.6",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "26.6.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-runtime/-/jest-runtime-26.6.3.tgz",
+      "integrity": "sha1-T2TvvPrDmDMbdLSzyC0n1AG4+is=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/globals": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^0.6.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^15.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-serializer/-/jest-serializer-26.6.2.tgz",
+      "integrity": "sha1-0Tmq/UaVfTpEjzps2r4pGboHQtE=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "graceful-fs": "^4.2.4"
+      }
+    },
+    "jest-snapshot": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+      "integrity": "sha1-87CvGssiMxaFC9FOG+6pg3+znIQ=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^26.6.2",
+        "@types/babel__traverse": "^7.0.4",
+        "@types/prettier": "^2.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^26.6.2",
+        "graceful-fs": "^4.2.4",
+        "jest-diff": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^26.6.2",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-util": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-util/-/jest-util-26.6.2.tgz",
+      "integrity": "sha1-kHU12+TVpstMR6ybkm9q8pV2y8E=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^2.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-validate/-/jest-validate-26.6.2.tgz",
+      "integrity": "sha1-I9OAlxWHFQRnNCkRw9e0rFerIOw=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "camelcase": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "6.2.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/camelcase/-/camelcase-6.2.1.tgz",
+          "integrity": "sha1-JQ/TUM/VVdDSFgsdUVEOr4Mm6G4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-watcher/-/jest-watcher-26.6.2.tgz",
+      "integrity": "sha1-pbaDuPnWjbyx19rjIXLSzKBZKXU=",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "jest-util": "^26.6.2",
+        "string-length": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha1-f3LLxNZDw2Xie5/XdfnQ6qnHqO0=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsdom": {
+      "version": "16.7.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha1-kYrnGWVCSxl8gZ+Bg6dU4Yl3txA=",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.6",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.6.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/acorn/-/acorn-8.6.0.tgz",
+          "integrity": "sha1-42kroOsaDIPqpPN/X6c2jdcUKJU=",
+          "dev": true
+        }
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+      "dev": true
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
+      "dev": true
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "http://ires.58corp.com/repository/58npm/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "http://ires.58corp.com/repository/58npm/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      }
+    },
+    "makeerror": {
+      "version": "1.0.12",
+      "resolved": "http://ires.58corp.com/repository/58npm/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha1-Pl3SB5qC6BLpg8xmEMSiyw6qgBo=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "mime-db": {
+      "version": "1.51.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha1-2f9iRRhZsYNC2WCFDcPPt35j+ww=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.34",
+      "resolved": "http://ires.58corp.com/repository/58npm/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha1-WnEvnsFQNRGpRYA2QPr+CdN5PCQ=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.51.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "dev": true
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha1-ZyFID+wqEaSImGERWki2y+fMjws=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "dev": true
+    },
+    "multimatch": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha1-jDwPbj6ESa2grz3SnvtJGjdRkbM=",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "http://ires.58corp.com/repository/58npm/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+      "dev": true
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "8.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/node-notifier/-/node-notifier-8.0.2.tgz",
+      "integrity": "sha1-8xZ6OO8NLIqGaoPjGMG6Dv63AsU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.2",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.0",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "node-releases": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha1-PR05XyBPHy8ppUNYuftnh2WtL8U=",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha1-eg//l49tv6TQBiOPusmO1BmMMlk=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha1-TyNqY3Pa4FZqbUPhMmZ09QwpFJk=",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "p-each-series": {
+      "version": "2.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha1-EFqwNXznKyAqiouUkzZyZXteKpo=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "http://ires.58corp.com/repository/58npm/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+      "dev": true
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pirates": {
+      "version": "4.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/pirates/-/pirates-4.0.4.tgz",
+      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha1-oC1q6+a6EzqSj3Suwguv3+a452A=",
+      "dev": true,
+      "requires": {
+        "find-up": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha1-rt3T+ZTJM+StmLmdmlVu+g4v6UI=",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "26.6.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        }
+      }
+    },
+    "pretty-quick": {
+      "version": "3.1.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/pretty-quick/-/pretty-quick-3.1.3.tgz",
+      "integrity": "sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "execa": "^4.0.0",
+        "find-up": "^4.1.0",
+        "ignore": "^5.1.4",
+        "mri": "^1.1.5",
+        "multimatch": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha1-TlSRrRVy8vF6d9OIxshXE1sihHo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "dev": true
+    },
+    "prompts": {
+      "version": "2.4.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha1-e1fnOzpIAprRDr1E90sBcipMsGk=",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "react-is": {
+      "version": "17.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "4.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/read-pkg/-/read-pkg-4.0.1.tgz",
+      "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+      "dev": true,
+      "requires": {
+        "normalize-package-data": "^2.3.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "http://ires.58corp.com/repository/58npm/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
+              "dev": true
+            }
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+          "dev": true
+        }
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha1-uTRtiCfo9aMve6KWN9OYtpAUhIo=",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "9.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
+      "integrity": "sha1-VNCccRXh9T3CMUqXSzLBw0Tv4yY=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "http://ires.58corp.com/repository/58npm/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha1-iSV0Kpj/2QgUmI11Zq0wyjsmO1I=",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha1-yY2hVGg2ccnE3LFuznNlF+G3/rQ=",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "4.8.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/regexpu-core/-/regexpu-core-4.8.0.tgz",
+      "integrity": "sha1-5WBbo2G2excYR4UBMnUC9EeamPA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^9.0.0",
+        "regjsgen": "^0.5.2",
+        "regjsparser": "^0.7.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.0.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.7.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/regjsparser/-/regjsparser-0.7.0.tgz",
+      "integrity": "sha1-prZntUyIXhi1JVTLSWDvcRh+mWg=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha1-vmgVIIR6tYx1aKx1+/rSjtQtOek=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "http://ires.58corp.com/repository/58npm/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.61.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/rollup/-/rollup-2.61.1.tgz",
+      "integrity": "sha512-BbTXlEvB8d+XFbK/7E5doIcRtxWPRiqr0eb5vQ0+2paMM04Ye4PZY5nHOQef2ix24l/L0SpLd5hwcH15QHPdvA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha1-6Pu6SGmYGy3DWufopQLVxsBNMk0=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      }
+    },
+    "rsvp": {
+      "version": "4.8.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha1-yPFVMR0Wf2jyHhaN9x7FsIMRNzQ=",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "6.6.7",
+      "resolved": "http://ires.58corp.com/repository/58npm/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+          "dev": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "sane": {
+      "version": "4.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/sane/-/sane-4.1.0.tgz",
+      "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
+      "dev": true,
+      "requires": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "http://ires.58corp.com/repository/58npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "http://ires.58corp.com/repository/58npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "http://ires.58corp.com/repository/58npm/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha1-7rq5U/o7dgjb6U5drbFciI+maW0=",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "3.1.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha1-srzG+X9jJp8oaZTil+IptiRdDcM=",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
+      "dev": true,
+      "optional": true
+    },
+    "signal-exit": {
+      "version": "3.0.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha1-JOYwxLDwP+pEaivSmeYrSmyo0K8=",
+      "dev": true
+    },
+    "single-spa": {
+      "version": "5.9.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/single-spa/-/single-spa-5.9.3.tgz",
+      "integrity": "sha1-LRUcuzsnNimlsnswo7jKhH3LpMU=",
+      "dev": true
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha1-UA6N0P1VsFgVCGJVsxla3ypF/ms=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://ires.58corp.com/repository/58npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+          "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.6.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha1-PZ34fiNrU/FtAeWBUPx3EROOXtI=",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "http://ires.58corp.com/repository/58npm/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY=",
+      "dev": true
+    },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "http://ires.58corp.com/repository/58npm/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "http://ires.58corp.com/repository/58npm/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha1-UMDYxAoU7Bv0Sbrmmg6kaFqdn5U=",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha1-0lJl/KmVFUZZ27+6O0klR3jS/dU=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
+          "dev": true
+        }
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://ires.58corp.com/repository/58npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha1-T3e0JIh2WJF3S3DHm6vYf5vVlLs=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
+      "dev": true
+    },
+    "table": {
+      "version": "6.7.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/table/-/table-6.7.5.tgz",
+      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha1-AbT+8gB6KL918Lf8AJ9iZ53kq7s=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha1-FKZKJ6s8Dfkz6lRvulXy0HjtyZQ=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "terser": {
+      "version": "5.10.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/terser/-/terser-5.10.0.tgz",
+      "integrity": "sha1-uGOQgJwDiRBesKC2I5dWMJbdr8w=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "dev": true
+        }
+      }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "5.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha1-xRmSNYA6rRh1SmZ9ZZtecs4Wdks=",
+      "dev": true
+    },
+    "tmpl": {
+      "version": "1.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://ires.58corp.com/repository/58npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      }
+    },
+    "tr46": {
+      "version": "2.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha1-+oeqgcpdWUHajL8fm3SdyWmk4kA=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "http://ires.58corp.com/repository/58npm/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
+      "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-MBrNxSVjFnDTn2FG4Od/9rvevdw=",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-VP0W4OyxZ88Ezx91a9zJLrp5dsM=",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-GgGqVyR8FMVouJd1pUk4eIGJpxQ=",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-CjbLmlhcT2q9Ua0d7dsoXBZSl8g=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "http://ires.58corp.com/repository/58npm/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "http://ires.58corp.com/repository/58npm/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/use/-/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha1-LeGWGMZtwkfc+2+ZM4A12CRaLO4=",
+      "dev": true
+    },
+    "v8-to-istanbul": {
+      "version": "7.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
+      "integrity": "sha1-MImNGn+gyE0iWiwUNPuVjykIg8E=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "http://ires.58corp.com/repository/58npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "dev": true
+        }
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "http://ires.58corp.com/repository/58npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha1-PnEEoFt1FGzGD1ZDgLf2g6zxAgo=",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "walker": {
+      "version": "1.0.8",
+      "resolved": "http://ires.58corp.com/repository/58npm/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha1-vUmNtHev5XPcBBhfAR06uKjXZT8=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ=",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "http://ires.58corp.com/repository/58npm/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha1-ZWp45RD/jzk3vAvL6fXArDWUG3c=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "http://ires.58corp.com/repository/58npm/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "7.5.6",
+      "resolved": "http://ires.58corp.com/repository/58npm/ws/-/ws-7.5.6.tgz",
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "http://ires.58corp.com/repository/58npm/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha1-IwHF/78StGfejaIzOkWeKeeSDks=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "http://ires.58corp.com/repository/58npm/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "http://ires.58corp.com/repository/58npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "http://ires.58corp.com/repository/58npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@testing-library/dom": "^7.29.4",
     "@testing-library/jest-dom": "^5.11.9",
     "@types/jest": "^26.0.20",
+    "axios": "^0.24.0",
     "babel-eslint": "^11.0.0-beta.2",
     "babel-jest": "^26.6.3",
     "concurrently": "^5.3.0",

--- a/src/single-spa-css.ts
+++ b/src/single-spa-css.ts
@@ -1,4 +1,5 @@
 import { AppProps, LifeCycleFn } from "single-spa";
+import axios from "axios";
 
 const defaultOptions: Required<SingleSpaCssOpts> = {
   cssUrls: [],
@@ -11,6 +12,7 @@ const defaultOptions: Required<SingleSpaCssOpts> = {
     linkEl.rel = "stylesheet";
     return linkEl;
   },
+  manifestUrl: "",
 };
 
 export default function singleSpaCss<ExtraProps>(
@@ -30,8 +32,17 @@ export default function singleSpaCss<ExtraProps>(
   if (!Array.isArray(opts.cssUrls)) {
     throw Error("single-spa-css: cssUrls must be an array");
   }
+  if (
+    opts.cssUrls.length > 0 &&
+    opts.cssUrls.filter((url) => url).length === 0
+  ) {
+    throw Error("single-spa-css: cssUrls should not be empty string");
+  }
 
   const allCssUrls = opts.cssUrls;
+
+  const manifestUrl = opts.manifestUrl;
+
   if (opts.webpackExtractedCss) {
     if (!__webpack_require__.cssAssets) {
       throw Error(
@@ -51,74 +62,112 @@ export default function singleSpaCss<ExtraProps>(
   const linkElements: LinkElements = {};
   let linkElementsToUnmount: ElementsToUnmount[] = [];
 
+  // 生成 preload 链接并插入到 head
+  function genPreloadLink2Head(url: string) {
+    const preloadEl = document.querySelector(
+      `link[rel="preload"][as="style"][href="${url}"]`
+    );
+
+    if (!preloadEl) {
+      const linkEl = document.createElement("link");
+      linkEl.rel = "preload";
+      linkEl.setAttribute("as", "style");
+      linkEl.href = url;
+
+      document.head.appendChild(linkEl);
+    }
+  }
+
   function bootstrap(props: AppProps) {
     return Promise.all(
-      allCssUrls.map(
-        (cssUrl) =>
-          new Promise<void>((resolve, reject) => {
-            const [url] = extractUrl(cssUrl);
-            const preloadEl = document.querySelector(
-              `link[rel="preload"][as="style"][href="${url}"]`
-            );
-
-            if (!preloadEl) {
-              const linkEl = document.createElement("link");
-              linkEl.rel = "preload";
-              linkEl.setAttribute("as", "style");
-              linkEl.href = url;
-
-              document.head.appendChild(linkEl);
-            }
-
-            // Don't wait for preload to finish before finishing bootstrap
-            resolve();
-          })
-      )
+      allCssUrls
+        .map(
+          (cssUrl) =>
+            new Promise<void>((resolve, reject) => {
+              const [url] = extractUrl(cssUrl);
+              genPreloadLink2Head(url);
+              // Don't wait for preload to finish before finishing bootstrap
+              resolve();
+            })
+        )
+        .concat(
+          manifestUrl
+            ? new Promise<void>((resolve) => {
+                extractManifestCssUrl(manifestUrl).then(([url]) => {
+                  genPreloadLink2Head(url);
+                });
+                // Don't wait for preload to finish before finishing bootstrap
+                resolve();
+              })
+            : []
+        )
     );
+  }
+
+  function genLink2Head(url, shouldUnmount, props, opts, resolve, reject) {
+    const existingLinkEl = document.querySelector(
+      `link[rel="stylesheet"][href="${url}"]`
+    );
+
+    if (existingLinkEl) {
+      linkElements[url] = existingLinkEl as HTMLLinkElement;
+      resolve();
+    } else {
+      const timeout = setTimeout(() => {
+        reject(
+          `single-spa-css: While mounting '${props.name}', loading CSS from URL ${linkEl.href} timed out after ${opts.timeout}ms`
+        );
+      }, opts.timeout);
+      const linkEl = opts.createLink(url);
+      linkEl.addEventListener("load", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+      linkEl.addEventListener("error", () => {
+        clearTimeout(timeout);
+        reject(
+          Error(
+            `single-spa-css: While mounting '${props.name}', loading CSS from URL ${linkEl.href} failed.`
+          )
+        );
+      });
+      linkElements[url] = linkEl;
+      document.head.appendChild(linkEl);
+
+      if (shouldUnmount) {
+        linkElementsToUnmount.push([linkEl, url]);
+      }
+    }
   }
 
   function mount(props: AppProps) {
     return Promise.all(
-      allCssUrls.map(
-        (cssUrl) =>
-          new Promise<void>((resolve, reject) => {
-            const [url, shouldUnmount] = extractUrl(cssUrl);
-
-            const existingLinkEl = document.querySelector(
-              `link[rel="stylesheet"][href="${url}"]`
-            );
-
-            if (existingLinkEl) {
-              linkElements[url] = existingLinkEl as HTMLLinkElement;
-              resolve();
-            } else {
-              const timeout = setTimeout(() => {
-                reject(
-                  `single-spa-css: While mounting '${props.name}', loading CSS from URL ${linkEl.href} timed out after ${opts.timeout}ms`
+      allCssUrls
+        .map(
+          (cssUrl) =>
+            new Promise<void>((resolve, reject) => {
+              const [url, shouldUnmount] = extractUrl(cssUrl);
+              genLink2Head(url, shouldUnmount, props, opts, resolve, reject);
+            })
+        )
+        .concat(
+          manifestUrl
+            ? new Promise<void>((resolve, reject) => {
+                extractManifestCssUrl(manifestUrl).then(
+                  ([url, shouldUnmount]) => {
+                    genLink2Head(
+                      url,
+                      shouldUnmount,
+                      props,
+                      opts,
+                      resolve,
+                      reject
+                    );
+                  }
                 );
-              }, opts.timeout);
-              const linkEl = opts.createLink(url);
-              linkEl.addEventListener("load", () => {
-                clearTimeout(timeout);
-                resolve();
-              });
-              linkEl.addEventListener("error", () => {
-                clearTimeout(timeout);
-                reject(
-                  Error(
-                    `single-spa-css: While mounting '${props.name}', loading CSS from URL ${linkEl.href} failed.`
-                  )
-                );
-              });
-              linkElements[url] = linkEl;
-              document.head.appendChild(linkEl);
-
-              if (shouldUnmount) {
-                linkElementsToUnmount.push([linkEl, url]);
-              }
-            }
-          })
-      )
+              })
+            : []
+        )
     );
   }
 
@@ -154,15 +203,31 @@ export default function singleSpaCss<ExtraProps>(
     }
   }
 
+  function extractManifestCssUrl(jsonUrl: string): Promise<[string, boolean]> {
+    const origin = /^(http|https)?:\/\/[\w-.]+(:\d+)?/i.exec(jsonUrl)![0];
+    let url = "";
+    return new Promise((resolve, reject) => {
+      axios.get(jsonUrl).then((res) => {
+        // TODO 这里可能存在多种格式的 manifest.json 文件，目前是最基础的格式
+        url = origin + "/" + res.data["main.css"];
+        resolve([
+          url,
+          opts.shouldUnmount, // 使用默认的
+        ]);
+      });
+    });
+  }
+
   return { bootstrap, mount, unmount };
 }
 
 type SingleSpaCssOpts = {
-  cssUrls: CssUrl[];
+  cssUrls?: CssUrl[];
   webpackExtractedCss?: boolean;
   timeout?: number;
   shouldUnmount?: boolean;
   createLink?: (url: string) => HTMLLinkElement;
+  manifestUrl?: string;
 };
 
 type CssUrl =


### PR DESCRIPTION
manifestUrl 用法

```js
const cssLifecycles = singleSpaCss({
  manifestUrl: `http://${host}/manifest.json`, //
  webpackExtractedCss: false,
});
```

> manifest 是 webpack-manifest-plugin 打包出的资源表
> support development & production