### PR TITLE
feat: export singleSpaCss return and parameter types

### DIFF
--- a/src/single-spa-css.ts
+++ b/src/single-spa-css.ts
@@ -157,7 +157,7 @@ export default function singleSpaCss<ExtraProps>(
   return { bootstrap, mount, unmount };
 }
 
-type SingleSpaCssOpts = {
+export type SingleSpaCssOpts = {
   cssUrls: CssUrl[];
   webpackExtractedCss?: boolean;
   timeout?: number;
@@ -178,7 +178,7 @@ type LinkElements = {
 
 type ElementsToUnmount = [HTMLLinkElement, string];
 
-type CSSLifecycles<ExtraProps> = {
+export type CSSLifecycles<ExtraProps> = {
   bootstrap: LifeCycleFn<ExtraProps>;
   mount: LifeCycleFn<ExtraProps>;
   unmount: LifeCycleFn<ExtraProps>;


### PR DESCRIPTION
This is probably self-explanatory, but I have a use case where I want to pass the return value of singleSpaCss of type CSSLifecycles through to another function as a parameter, and thus I need this exported to type the parameter properly.