### PR TITLE
feat: support `customProps.cssUrls`

### DIFF
--- a/src/single-spa-css.test.ts
+++ b/src/single-spa-css.test.ts
@@ -22,7 +22,7 @@ describe("single-spa-css", () => {
     expect(() => singleSpaCss({ cssUrls: "/main.css" })).toThrowError();
   });
 
-  it(`throws if appProps.cssUrls is not an array`, () => {
+  it(`throws if customProps.cssUrls is not an array`, () => {
     const url = "https://example.com/main.css";
 
     const lifecycles = singleSpaCss<{}>({

--- a/src/single-spa-css.test.ts
+++ b/src/single-spa-css.test.ts
@@ -17,23 +17,42 @@ describe("single-spa-css", () => {
     expect(() => singleSpaCss("asdfsdf")).toThrowError();
   });
 
-  it(`throws if cssUrls is not an array`, () => {
+  it(`throws if opts.cssUrls is not an array`, () => {
     // @ts-ignore
     expect(() => singleSpaCss({ cssUrls: "/main.css" })).toThrowError();
   });
 
-  it(`preloads scripts during the bootstrap lifecycle`, async () => {
+  it(`throws if appProps.cssUrls is not an array`, () => {
     const url = "https://example.com/main.css";
 
     const lifecycles = singleSpaCss<{}>({
       cssUrls: [url],
     });
 
-    expect(findPreloadEl(url)).not.toBeInTheDocument();
+    expect(() =>
+      lifecycles.bootstrap({
+        ...createProps(),
+        // @ts-ignore
+        cssUrls: "/main.css",
+      })
+    ).toThrowError();
+  });
 
-    await lifecycles.bootstrap(createProps());
+  it(`preloads scripts during the bootstrap lifecycle`, async () => {
+    const url1 = "https://example.com/main_1.css";
+    const url2 = "https://example.com/main_2.css";
 
-    expect(findPreloadEl(url)).toBeInTheDocument();
+    const lifecycles = singleSpaCss<{}>({
+      cssUrls: [url1],
+    });
+
+    expect(findPreloadEl(url1)).not.toBeInTheDocument();
+    expect(findPreloadEl(url2)).not.toBeInTheDocument();
+
+    await lifecycles.bootstrap({ ...createProps(), cssUrls: [url2] });
+
+    expect(findPreloadEl(url1)).toBeInTheDocument();
+    expect(findPreloadEl(url2)).toBeInTheDocument();
   });
 
   it(`mounts <link> elements and waits for them to load before resolving the mount promise. Then it unmounts them`, async () => {

--- a/src/single-spa-css.ts
+++ b/src/single-spa-css.ts
@@ -13,9 +13,7 @@ const defaultOptions: Required<SingleSpaCssOpts> = {
   },
 };
 
-export default function singleSpaCss<ExtraProps>(
-  _opts: SingleSpaCssOpts
-): CSSLifecycles<ExtraProps> {
+export default function singleSpaCss(_opts: SingleSpaCssOpts): CSSLifecycles {
   if (!_opts || typeof _opts !== "object") {
     throw Error(`single-spa-css: opts must be an object`);
   }
@@ -51,9 +49,10 @@ export default function singleSpaCss<ExtraProps>(
   const linkElements: LinkElements = {};
   let linkElementsToUnmount: ElementsToUnmount[] = [];
 
-  function bootstrap(props: AppProps) {
+  function bootstrap(props: AppPropsWithCssExtra) {
+    const cssUrls = [...(props.cssUrls ?? []), ...allCssUrls];
     return Promise.all(
-      allCssUrls.map(
+      cssUrls.map(
         (cssUrl) =>
           new Promise<void>((resolve, reject) => {
             const [url] = extractUrl(cssUrl);
@@ -77,9 +76,11 @@ export default function singleSpaCss<ExtraProps>(
     );
   }
 
-  function mount(props: AppProps) {
+  function mount(props: AppPropsWithCssExtra) {
+    const cssUrls = [...(props.cssUrls ?? []), ...allCssUrls];
+
     return Promise.all(
-      allCssUrls.map(
+      cssUrls.map(
         (cssUrl) =>
           new Promise<void>((resolve, reject) => {
             const [url, shouldUnmount] = extractUrl(cssUrl);
@@ -122,7 +123,7 @@ export default function singleSpaCss<ExtraProps>(
     );
   }
 
-  function unmount(props: AppProps) {
+  function unmount(props: AppPropsWithCssExtra) {
     const elements = linkElementsToUnmount;
 
     // reset this array immediately so that only one mounted instance tries to unmount
@@ -178,8 +179,12 @@ type LinkElements = {
 
 type ElementsToUnmount = [HTMLLinkElement, string];
 
-type CSSLifecycles<ExtraProps> = {
-  bootstrap: LifeCycleFn<ExtraProps>;
-  mount: LifeCycleFn<ExtraProps>;
-  unmount: LifeCycleFn<ExtraProps>;
+interface AppPropsWithCssExtra extends AppProps {
+  cssUrls?: CssUrl[];
+}
+
+type CSSLifecycles = {
+  bootstrap: LifeCycleFn<AppPropsWithCssExtra>;
+  mount: LifeCycleFn<AppPropsWithCssExtra>;
+  unmount: LifeCycleFn<AppPropsWithCssExtra>;
 };

--- a/src/single-spa-css.ts
+++ b/src/single-spa-css.ts
@@ -50,7 +50,16 @@ export default function singleSpaCss(_opts: SingleSpaCssOpts): CSSLifecycles {
   let linkElementsToUnmount: ElementsToUnmount[] = [];
 
   function bootstrap(props: AppPropsWithCssExtra) {
-    const cssUrls = [...(props.cssUrls ?? []), ...allCssUrls];
+    const cssUrls: CssUrl[] = [...allCssUrls];
+
+    if (props.cssUrls) {
+      if (!Array.isArray(props.cssUrls)) {
+        throw Error("single-spa-css: cssUrls must be an array");
+      }
+
+      cssUrls.push(...props.cssUrls);
+    }
+
     return Promise.all(
       cssUrls.map(
         (cssUrl) =>

--- a/src/single-spa-css.ts
+++ b/src/single-spa-css.ts
@@ -13,7 +13,9 @@ const defaultOptions: Required<SingleSpaCssOpts> = {
   },
 };
 
-export default function singleSpaCss(_opts: SingleSpaCssOpts): CSSLifecycles {
+export default function singleSpaCss<ExtraProps>(
+  _opts: SingleSpaCssOpts
+): CSSLifecycles<ExtraProps> {
   if (!_opts || typeof _opts !== "object") {
     throw Error(`single-spa-css: opts must be an object`);
   }
@@ -49,7 +51,7 @@ export default function singleSpaCss(_opts: SingleSpaCssOpts): CSSLifecycles {
   const linkElements: LinkElements = {};
   let linkElementsToUnmount: ElementsToUnmount[] = [];
 
-  function bootstrap(props: AppPropsWithCssExtra) {
+  function bootstrap(props: AppProps & CssExtraProps & ExtraProps) {
     const cssUrls: CssUrl[] = [...allCssUrls];
 
     if (props.cssUrls) {
@@ -85,7 +87,7 @@ export default function singleSpaCss(_opts: SingleSpaCssOpts): CSSLifecycles {
     );
   }
 
-  function mount(props: AppPropsWithCssExtra) {
+  function mount(props: AppProps & CssExtraProps & ExtraProps) {
     const cssUrls = [...(props.cssUrls ?? []), ...allCssUrls];
 
     return Promise.all(
@@ -132,7 +134,7 @@ export default function singleSpaCss(_opts: SingleSpaCssOpts): CSSLifecycles {
     );
   }
 
-  function unmount(props: AppPropsWithCssExtra) {
+  function unmount(props: AppProps & CssExtraProps & ExtraProps) {
     const elements = linkElementsToUnmount;
 
     // reset this array immediately so that only one mounted instance tries to unmount
@@ -188,12 +190,12 @@ type LinkElements = {
 
 type ElementsToUnmount = [HTMLLinkElement, string];
 
-interface AppPropsWithCssExtra extends AppProps {
+type CssExtraProps = {
   cssUrls?: CssUrl[];
-}
+};
 
-type CSSLifecycles = {
-  bootstrap: LifeCycleFn<AppPropsWithCssExtra>;
-  mount: LifeCycleFn<AppPropsWithCssExtra>;
-  unmount: LifeCycleFn<AppPropsWithCssExtra>;
+type CSSLifecycles<ExtraProps> = {
+  bootstrap: LifeCycleFn<AppProps & CssExtraProps & ExtraProps>;
+  mount: LifeCycleFn<AppProps & CssExtraProps & ExtraProps>;
+  unmount: LifeCycleFn<AppProps & CssExtraProps & ExtraProps>;
 };

--- a/src/single-spa-css.ts
+++ b/src/single-spa-css.ts
@@ -1,4 +1,4 @@
-import { AppProps, LifeCycleFn } from "single-spa";
+import { AppProps, LifeCycleFn, CustomProps } from "single-spa";
 
 const defaultOptions: Required<SingleSpaCssOpts> = {
   cssUrls: [],
@@ -51,7 +51,7 @@ export default function singleSpaCss<ExtraProps>(
   const linkElements: LinkElements = {};
   let linkElementsToUnmount: ElementsToUnmount[] = [];
 
-  function bootstrap(props: AppProps & CssExtraProps & ExtraProps) {
+  function bootstrap(props: AppProps & CssCustomProps & ExtraProps) {
     const cssUrls: CssUrl[] = [...allCssUrls];
 
     if (props.cssUrls) {
@@ -87,7 +87,7 @@ export default function singleSpaCss<ExtraProps>(
     );
   }
 
-  function mount(props: AppProps & CssExtraProps & ExtraProps) {
+  function mount(props: AppProps & CssCustomProps & ExtraProps) {
     const cssUrls = [...(props.cssUrls ?? []), ...allCssUrls];
 
     return Promise.all(
@@ -134,7 +134,7 @@ export default function singleSpaCss<ExtraProps>(
     );
   }
 
-  function unmount(props: AppProps & CssExtraProps & ExtraProps) {
+  function unmount(props: AppProps & CssCustomProps & ExtraProps) {
     const elements = linkElementsToUnmount;
 
     // reset this array immediately so that only one mounted instance tries to unmount
@@ -190,12 +190,12 @@ type LinkElements = {
 
 type ElementsToUnmount = [HTMLLinkElement, string];
 
-type CssExtraProps = {
+type CssCustomProps = {
   cssUrls?: CssUrl[];
 };
 
 type CSSLifecycles<ExtraProps> = {
-  bootstrap: LifeCycleFn<AppProps & CssExtraProps & ExtraProps>;
-  mount: LifeCycleFn<AppProps & CssExtraProps & ExtraProps>;
-  unmount: LifeCycleFn<AppProps & CssExtraProps & ExtraProps>;
+  bootstrap: LifeCycleFn<AppProps & CssCustomProps & ExtraProps>;
+  mount: LifeCycleFn<AppProps & CssCustomProps & ExtraProps>;
+  unmount: LifeCycleFn<AppProps & CssCustomProps & ExtraProps>;
 };


### PR DESCRIPTION
Sorry for creating PR without asking in issues.

## Motivation

I want my single-spa application be able to load css provided from  root-config.

An application’s bundled css filename sometimes includes hash (`index.abcdef.css`) Hash text is detemined in build-time, so bundled js file cannot know hashed css file url. In case single-spa(-css), css urls received in opts.cssUrls cannot has build-time hash.



## Example

```js
// single-spa root-config
registerApplication({
  name: 'app1',
  activeWhen: '/app1',
  app: () => import('https://example.com/main.build-time-hash.js'),
  customProps: {
    cssUrls: ['https://example.com/main.build-time-hash.css'] 👈
  }
});
```

```js
// single-spa application
const cssLifecycles = singleSpaCss({
  cssUrls: [],
});
```
