### PR TITLE
fix: resolve ExposeRuntimeCssAssetsPlugin.js files path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-css",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Lifecycle helpers for loading CSS",
   "type": "module",
   "exports": {
@@ -24,7 +24,7 @@
   },
   "files": [
     "lib",
-    "ExposeRuntimeCssAssetsPlugin.cjs"
+    "ExposeRuntimeCssAssetsPlugin.js"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-css",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "description": "Lifecycle helpers for loading CSS",
   "type": "module",
   "exports": {


### PR DESCRIPTION
See related #30 

ExposeRuntimeCssAssetsPlugin is not included in the published files
![image](https://github.com/user-attachments/assets/6913cf54-b044-428c-90e2-1d5d6f575a8e)
